### PR TITLE
Fixed calendar icon for Plone 4.3 sites.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.0.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed calendar icon for Plone 4.3 sites.
+  [phgross]
 
 
 1.0.4 (2014-02-12)

--- a/ftw/datepicker/widget.py
+++ b/ftw/datepicker/widget.py
@@ -35,7 +35,7 @@ class DatePickerWidget(widget.HTMLTextInputWidget, Widget):
                 });
             });
             /* ]]> */""" % dict(id=self.id,
-                    buttonImage='%s/popup_calendar.gif' % self.portal_url())
+                    buttonImage='%s/popup_calendar.png' % self.portal_url())
 
 
 @adapter(IDatePickerWidget, IFormLayer)


### PR DESCRIPTION
The calendar icon is no longer available as `popup_calendar.gif` in Plone 4.3, the `popup_calendar.png` works also for former plone versions.

https://github.com/4teamwork/opengever.core/pull/982

@lukasgraf 