### PR TITLE
Make it possible to use different dateformats depending on the current language.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.0.6 (unreleased)
 ------------------
 
+- Make it possible to use different dateformats depending on the current language.
+  [tschanzt]
+
 - Use DateTimePicker widget from XDSoft which also supports time picking
   (http://xdsoft.net/jqplugins/datetimepicker/).
   Attention: Support for Plone 4.0.x has been dropped.

--- a/ftw/datepicker/configure.zcml
+++ b/ftw/datepicker/configure.zcml
@@ -30,6 +30,7 @@
 
     <adapter factory=".widget.DateTimePickerWidgetFactory" />
     <adapter factory=".converter.DateTimeDataConverter" />
+    <adapter factory=".converter.DateDataConverter" />
 
     <z3c:widgetTemplate
         mode="input"

--- a/ftw/datepicker/interfaces.py
+++ b/ftw/datepicker/interfaces.py
@@ -1,5 +1,6 @@
 from z3c.form.interfaces import ITextWidget
 from zope.interface import Interface
+from plone.registry import field
 
 
 class IBrowserLayer(Interface):
@@ -8,3 +9,9 @@ class IBrowserLayer(Interface):
 
 class IDateTimePickerWidget(ITextWidget):
     """Marker interface for datetimepicker widget"""
+
+
+class IDatetimeRegistry(Interface):
+    formats = field.Dict(title=u"Formats",
+        key_type=field.TextLine(title=u"Language"),
+        value_type=field.TextLine(title=u"Dateformat"))

--- a/ftw/datepicker/interfaces.py
+++ b/ftw/datepicker/interfaces.py
@@ -1,3 +1,4 @@
+from ftw.datepicker import _
 from z3c.form.interfaces import ITextWidget
 from zope.interface import Interface
 from plone.registry import field
@@ -12,6 +13,12 @@ class IDateTimePickerWidget(ITextWidget):
 
 
 class IDatetimeRegistry(Interface):
-    formats = field.Dict(title=u"Formats",
-        key_type=field.TextLine(title=u"Language"),
-        value_type=field.TextLine(title=u"Dateformat"))
+    formats = field.Dict(
+        title=_(u'datetime_registry_title', default=u'Formats'),
+        key_type=field.TextLine(
+            title=_(u'datetime_registry_key_type', default=u'Language')
+        ),
+        value_type=field.TextLine(
+            title=_(u'datetime_registry_value_type', default=u'Date format'),
+        )
+    )

--- a/ftw/datepicker/locales/de/LC_MESSAGES/ftw.datepicker.po
+++ b/ftw/datepicker/locales/de/LC_MESSAGES/ftw.datepicker.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2011-01-12 14:44+0000\n"
+"POT-Creation-Date: 2015-08-17 12:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -10,9 +10,23 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
-"Domain: DOMAIN\n"
 
-#: ./ftw/datepicker/converter.py:43
+#. Default: "Language"
+#: ./ftw/datepicker/interfaces.py:19
+msgid "datetime_registry_key_type"
+msgstr "Sprache"
+
+#. Default: "Formats"
+#: ./ftw/datepicker/interfaces.py:17
+msgid "datetime_registry_title"
+msgstr "Formate"
+
+#. Default: "Date format"
+#: ./ftw/datepicker/interfaces.py:22
+msgid "datetime_registry_value_type"
+msgstr "Datumsformat"
+
+#: ./ftw/datepicker/converter.py:53
 msgid "error_datetime_parse"
 msgstr "Kein gültiges Datumsformat (Beispiel: 15. Januar 2011)."
 

--- a/ftw/datepicker/locales/fr/LC_MESSAGES/ftw.datepicker.po
+++ b/ftw/datepicker/locales/fr/LC_MESSAGES/ftw.datepicker.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2011-01-12 14:44+0000\n"
+"POT-Creation-Date: 2015-08-17 12:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -10,9 +10,24 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
-"Domain: DOMAIN\n"
 
-#: ./ftw/datepicker/converter.py:43
+#. Default: "Language"
+#: ./ftw/datepicker/interfaces.py:19
+msgid "datetime_registry_key_type"
+msgstr "Langue"
+
+#. Default: "Formats"
+#: ./ftw/datepicker/interfaces.py:17
+msgid "datetime_registry_title"
+msgstr "Formats"
+
+#. Default: "Date format"
+#: ./ftw/datepicker/interfaces.py:22
+msgid "datetime_registry_value_type"
+msgstr "Format de date"
+
+#: ./ftw/datepicker/converter.py:53
 msgid "error_datetime_parse"
 msgstr "Format de date non valable (exemple: 15 janvier 2011)"
+
 

--- a/ftw/datepicker/locales/ftw.datepicker.pot
+++ b/ftw/datepicker/locales/ftw.datepicker.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2011-01-12 14:44+0000\n"
+"POT-Creation-Date: 2015-08-17 12:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -12,12 +12,25 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
-"Language-Code: en\n"
-"Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
-"Domain: ftw.datepicker\n"
 
-#: ./ftw/datepicker/converter.py:43
+#. Default: "Language"
+#: ./ftw/datepicker/interfaces.py:19
+msgid "datetime_registry_key_type"
+msgstr ""
+
+#. Default: "Formats"
+#: ./ftw/datepicker/interfaces.py:17
+msgid "datetime_registry_title"
+msgstr ""
+
+#. Default: "Date format"
+#: ./ftw/datepicker/interfaces.py:22
+msgid "datetime_registry_value_type"
+msgstr ""
+
+#: ./ftw/datepicker/converter.py:53
 msgid "error_datetime_parse"
 msgstr ""
+
 

--- a/ftw/datepicker/profiles/default/registry.xml
+++ b/ftw/datepicker/profiles/default/registry.xml
@@ -1,0 +1,10 @@
+<registry>
+
+<record interface="ftw.datepicker.interfaces.IDatetimeRegistry" field="formats">
+    <value purge="false">
+        <element key="de">d.m.Y H:i</element>
+        <element key="fr">d/m/Y H:i</element>
+    </value>
+</record>
+
+</registry>

--- a/ftw/datepicker/resources/js/datetimepicker_widget.js
+++ b/ftw/datepicker/resources/js/datetimepicker_widget.js
@@ -3,12 +3,32 @@ $(function(){
   initDateTimePicker = function(){
     $("input.datetimepicker-widget").each(function(i, o){
       var field = $(this);
+      var lang = $('html').attr('lang')
       var widget_data = field.data("datetimewidget");
+      var params = {};
+      if (widget_data[lang]){
+          params['format'] = widget_data[lang];
+
+      }
+      else if (widget_data[lang.split('-')[0]]){
+        params['format'] = widget_data[lang.split('-')[0]];
+
+      }
+      else {
+          params['format'] = "d.m.Y H:i";
+      }
+      if (lang.indexOf('-') > -1){
+        lang = lang.split('-')[0];
+      }
+      params['lang'] = lang;
+      if (field.hasClass('date-field')){
+        params['timepicker'] = false;
+        params['format'] = params['format'].split(' ')[0];
+      }
       if (!field.val()){
         field.datetimepicker("destroy");  // May be initialized falsy, e.g. by datagridwidget
       }
-
-      field.datetimepicker(widget_data);
+      field.datetimepicker(params);
     });
   };
 

--- a/ftw/datepicker/testing.py
+++ b/ftw/datepicker/testing.py
@@ -6,6 +6,8 @@ from plone.app.testing import FunctionalTesting
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
 from zope.configuration import xmlconfig
+from Products.CMFCore.utils import getToolByName
+import transaction
 
 
 class FtwDatepickerLayer(PloneSandboxLayer):
@@ -28,7 +30,10 @@ class FtwDatepickerLayer(PloneSandboxLayer):
 
     def setUpPloneSite(self, portal):
         # Install into Plone site using portal_setup
+        switch_language(portal, 'de')
+        applyProfile(portal, 'plone.app.registry:default')
         applyProfile(portal, 'ftw.datepicker:default')
+
 
 FTW_DATEPICKER_FIXTURE = FtwDatepickerLayer()
 
@@ -36,3 +41,12 @@ FTW_DATEPICKER_FUNCTIONAL_TESTING = FunctionalTesting(
     bases=(FTW_DATEPICKER_FIXTURE,
            set_builder_session_factory(functional_session_factory)),
     name="ftw.datepicker:functional")
+
+
+def switch_language(portal, lang):
+    language_tool = getToolByName(portal, 'portal_languages')
+    language_tool.manage_setLanguageSettings(
+        lang, ['de', 'fr', 'en'],
+        setUseCombinedLanguageCodes=False, startNeutral=False)
+    portal.setLanguage(lang)
+    transaction.commit()

--- a/ftw/datepicker/tests/test_dateconverter.py
+++ b/ftw/datepicker/tests/test_dateconverter.py
@@ -1,0 +1,41 @@
+from datetime import date
+from ftw.datepicker.converter import DateDataConverter
+from ftw.datepicker.tests import FunctionalTestCase
+from ftw.datepicker.widget import DateTimePickerWidget
+from z3c.form.converter import FormatterValidationError
+from z3c.form.testing import TestRequest
+from zope import schema
+
+
+class TestDateConverter(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestDateConverter, self).setUp()
+        request = TestRequest()
+
+        datetime_field = schema.Date()
+
+        widget = DateTimePickerWidget(request)
+        widget.form = schema.Field()
+        self.converter = DateDataConverter(datetime_field, widget)
+
+    def test_toWidgetValue_with_german_js_format_by_default(self):
+        value = self.converter.toWidgetValue(date(2015, 6, 24))
+        self.assertEquals('24.06.2015', value)
+
+    def test_toFieldValue_with_german_js_format_by_default(self):
+        value = self.converter.toFieldValue('24.06.2015')
+        self.assertEquals(date(2015, 6, 24), value)
+
+    def test_toFieldValue_is_none_if_empty_string(self):
+        value = self.converter.toFieldValue(u'')
+        self.assertIsNone(value, 'Expect none if data is empty string.')
+
+    def test_toFieldValue_raises_formatter_error_if_data_are_invalid(self):
+        """
+        The widget expects the time by default. This test makes sure the
+        widget renders an error if no time is provided.
+        """
+        with self.assertRaises(FormatterValidationError):
+            self.converter.toFieldValue(u'24.06.2015 08:15')
+

--- a/ftw/datepicker/tests/test_datetimeconverter.py
+++ b/ftw/datepicker/tests/test_datetimeconverter.py
@@ -1,4 +1,4 @@
-from datetime import datetime, time
+from datetime import datetime
 from ftw.datepicker.converter import DateTimeDataConverter, transform_js_format
 from ftw.datepicker.tests import FunctionalTestCase
 from ftw.datepicker.widget import DateTimePickerWidget
@@ -7,17 +7,16 @@ from z3c.form.testing import TestRequest
 from zope import schema
 
 
-class TestConverter(FunctionalTestCase):
+class TestDatetimeConverter(FunctionalTestCase):
 
     def setUp(self):
-        super(TestConverter, self).setUp()
-
+        super(TestDatetimeConverter, self).setUp()
         request = TestRequest()
+
         datetime_field = schema.Datetime()
 
         widget = DateTimePickerWidget(request)
         widget.form = schema.Field()
-
         self.converter = DateTimeDataConverter(datetime_field, widget)
 
     def test_toWidgetValue_with_german_js_format_by_default(self):

--- a/ftw/datepicker/tests/test_widget.py
+++ b/ftw/datepicker/tests/test_widget.py
@@ -2,7 +2,6 @@ from ftw.datepicker.tests import FunctionalTestCase
 from ftw.testbrowser import browsing
 from Products.CMFCore.utils import getToolByName
 
-
 class TestWidget(FunctionalTestCase):
 
     def setUp(self):
@@ -29,8 +28,15 @@ class TestWidget(FunctionalTestCase):
             in css_registry.getResourceIds())
 
     @browsing
-    def test_fill_field_with_browser(self, browser):
+    def test_fill_field_with_browser_datetime(self, browser):
         browser.login().visit(view='test-z3cform-task')
         browser.fill({u'Due Date': u'24.06.2015 10:00'})
         browser.find('Submit').click()
         self.assertEquals({u'due_date': u'2015-06-24T10:00:00'}, browser.json)
+
+    @browsing
+    def test_fill_field_with_browser_date(self, browser):
+        browser.login().visit(view='test-z3cform-task')
+        browser.fill({u'Publish Date': u'24.06.2015'})
+        browser.find('Submit').click()
+        self.assertEquals({u'publish_date': u'2015-06-24'}, browser.json)

--- a/ftw/datepicker/tests/test_widget_second_language.py
+++ b/ftw/datepicker/tests/test_widget_second_language.py
@@ -1,0 +1,33 @@
+from ftw.datepicker.tests import FunctionalTestCase
+from ftw.datepicker.testing import switch_language
+from ftw.testbrowser import browsing
+
+
+class TestWidget(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestWidget, self).setUp()
+        self.grant('Manager')
+        switch_language(self.layer['portal'], 'fr')
+
+    @browsing
+    def test_fill_field_with_browser_datetime_french(self, browser):
+        browser.login().visit(view='test-z3cform-task')
+        browser.fill({u'Due Date': u'24/06/2015 08:15'})
+        browser.find('Submit').click()
+        self.assertEquals({u'due_date': u'2015-06-24T08:15:00'}, browser.json)
+
+    @browsing
+    def test_fill_field_with_browser_date_french(self, browser):
+        browser.login().visit(view='test-z3cform-task')
+        browser.fill({u'Publish Date': u'24/06/2015'})
+        browser.find('Submit').click()
+        self.assertEquals({u'publish_date': u'2015-06-24'}, browser.json)
+
+    @browsing
+    def test_fill_field_with_browser_date_unknown(self, browser):
+        switch_language(self.layer['portal'], 'en')
+        browser.login().visit(view='test-z3cform-task')
+        browser.fill({u'Publish Date': u'24.06.2015'})
+        browser.find('Submit').click()
+        self.assertEquals({u'publish_date': u'2015-06-24'}, browser.json)

--- a/ftw/datepicker/tests/views/z3cforms.py
+++ b/ftw/datepicker/tests/views/z3cforms.py
@@ -13,9 +13,11 @@ import json
 class ITaskFormSchema(Interface):
     due_date = schema.Datetime(
         title=u'Due Date',
-        required=True,
+        required=False,
     )
-
+    publish_date = schema.Date(
+        title=u'Publish Date',
+        required=False)
 
 class TaskForm(Form):
     label = u'Shopping'
@@ -28,6 +30,7 @@ class TaskForm(Form):
 
     def update(self):
         self.fields['due_date'].widgetFactory = DateTimePickerWidgetFactory
+        self.fields['publish_date'].widgetFactory = DateTimePickerWidgetFactory
         return super(TaskForm, self).update()
 
     @buttonAndHandler(u'Submit')

--- a/ftw/datepicker/upgrades/20150814100221_add_registry_for_datetimepicker/registry.xml
+++ b/ftw/datepicker/upgrades/20150814100221_add_registry_for_datetimepicker/registry.xml
@@ -1,0 +1,10 @@
+<registry>
+
+<record interface="ftw.datepicker.interfaces.IDatetimeRegistry" field="formats">
+    <value purge="false">
+        <element key="de">d.m.Y H:i</element>
+        <element key="fr">d/m/Y H:i</element>
+    </value>
+</record>
+
+</registry>

--- a/ftw/datepicker/upgrades/20150814100221_add_registry_for_datetimepicker/upgrade.py
+++ b/ftw/datepicker/upgrades/20150814100221_add_registry_for_datetimepicker/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddRegistryForDatetimepicker(UpgradeStep):
+    """Add registry for datetimepicker.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/ftw/datepicker/widget.py
+++ b/ftw/datepicker/widget.py
@@ -8,6 +8,9 @@ from zope.component import adapter
 from zope.interface import implementer
 from zope.interface import implementsOnly
 import json
+from plone.registry.interfaces import IRegistry
+from zope.component import getUtility
+from ftw.datepicker.interfaces import IDatetimeRegistry
 
 
 class DateTimePickerWidget(widget.HTMLTextInputWidget, Widget):
@@ -24,8 +27,9 @@ class DateTimePickerWidget(widget.HTMLTextInputWidget, Widget):
         if callable(config):
             self.config = config()
         elif not config:
-            self.config = {'format': 'd.m.Y H:i'}
-
+            registry = getUtility(IRegistry)
+            datesettings = registry.forInterface(IDatetimeRegistry)
+            self.config = datesettings.formats
         self.validate_config()
 
     def update(self):


### PR DESCRIPTION
@maethu This Pr enables you to use different dateformats in the widget depending on the current selected Language. if no configuration is found it falls back to the format 12.08.2015 08:15(without time if it is a date field). The Formats are managed with the portal_registry so they can be easily changed and extended.