### PR TITLE
fix tests by removing unneeded test dependencies.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,13 +5,12 @@ version = '1.1.1.dev0'
 maintainer = 'Thomas Buchberger'
 
 tests_require = [
-    'collective.testcaselayer',
     'ftw.builder',
     'ftw.testbrowser',
     'plone.app.testing',
     'plone.testing',
-    'z3c.form[test]',
     'unittest2',
+    'zope.app.testing',
 ]
 
 setup(name='ftw.datepicker',


### PR DESCRIPTION
- `collective.testcaselayer` is no longer needed, we use `plone.app.testing`. `collective.testcaselayer` is the old Plone testing infrastructure and should no longer be used and was in fact refactored in this package already.
- `z3c.form[test]` introduces the test problems and I'm not sure why it was added in the first place..