### PR TITLE
Fix import/export of registry.xml.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix import/export of registry.xml.
+  [mbaechtold]
 
 
 1.1.1 (2015-12-04)

--- a/ftw/datepicker/profiles/default/registry.xml
+++ b/ftw/datepicker/profiles/default/registry.xml
@@ -1,10 +1,14 @@
 <registry>
 
-<record interface="ftw.datepicker.interfaces.IDatetimeRegistry" field="formats">
+<record name="ftw.datepicker.interfaces.IDatetimeRegistry.formats">
+    <field type="plone.registry.field.Dict">
+        <title>The formats per language</title>
+        <key_type type="plone.registry.field.TextLine" />
+        <value_type type="plone.registry.field.TextLine" />
+    </field>
     <value purge="false">
         <element key="de">d.m.Y H:i</element>
         <element key="fr">d/m/Y H:i</element>
     </value>
 </record>
-
 </registry>


### PR DESCRIPTION
This fixes a problem in the test setup of an existing project: after running the tests of one test layer an error occurred during the tear down of it, before setting up another test layer.

For example:
Setting up one layer applies the kind of `broken` registry.xml and before setting up the second layer the first layer tears down the wrong way (Don't know whats wrong) and introduces the problem in setting up the second layer.  

```
ConnectionStateError: Shouldn't load state for 0x3a5192e7a775ec12 when the connection is closed

Running zope.testrunner.layer.UnitTests tests:
  Tear down plone.app.testing.layers.PloneFixture in 0.067 seconds.
  Tear down plone.testing.z2.Startup 
Traceback (most recent call last):
  File "bin/test", line 447, in <module>
    sys.exit(collective.xmltestreport.runner.run_internal(['-s', 'izug.organisation', '--exit-with-status', '--auto-color', '--auto-progress', '--xml', '--test-path', '/Users/mbaechtold/Developer/Projects/izug.organisation.simplelayout']))
  File "/Users/mbaechtold/.buildout/eggs/collective.xmltestreport-1.3.3-py2.7.egg/collective/xmltestreport/runner.py", line 73, in run_internal
    runner.run()
  File "/Users/mbaechtold/.buildout/eggs/zope.testrunner-4.4.4-py2.7.egg/zope/testrunner/runner.py", line 160, in run
    self.run_tests()
  File "/Users/mbaechtold/.buildout/eggs/zope.testrunner-4.4.4-py2.7.egg/zope/testrunner/runner.py", line 242, in run_tests
    self.skipped, self.import_errors)
  File "/Users/mbaechtold/.buildout/eggs/zope.testrunner-4.4.4-py2.7.egg/zope/testrunner/runner.py", line 394, in run_layer
    tear_down_unneeded(options, needed, setup_layers)
  File "/Users/mbaechtold/.buildout/eggs/zope.testrunner-4.4.4-py2.7.egg/zope/testrunner/runner.py", line 685, in tear_down_unneeded
    l.tearDown()
  File "/Users/mbaechtold/.buildout/eggs/plone.testing-4.1.1-py2.7.egg/plone/testing/z2.py", line 354, in tearDown
    self.tearDownBasicProducts()
  File "/Users/mbaechtold/.buildout/eggs/plone.testing-4.1.1-py2.7.egg/plone/testing/z2.py", line 676, in tearDownBasicProducts
    with zopeApp() as app:
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/contextlib.py", line 17, in __enter__
    return self.gen.next()
  File "/Users/mbaechtold/.buildout/eggs/plone.testing-4.1.1-py2.7.egg/plone/testing/z2.py", line 276, in zopeApp
    app = addRequestContainer(Zope2.app(connection), environ=environ)
  File "/Users/mbaechtold/.buildout/eggs/Zope2-2.13.24-py2.7.egg/Zope2/__init__.py", line 52, in app
    return bobo_application(*args, **kw)
  File "/Users/mbaechtold/.buildout/eggs/Zope2-2.13.24-py2.7.egg/App/ZApplication.py", line 75, in __call__
    return connection.root()[aname]
  File "/Users/mbaechtold/.buildout/eggs/ZODB3-3.10.5-py2.7-macosx-10.11-x86_64.egg/ZODB/Connection.py", line 366, in root
    return RootConvenience(self.get(z64))
  File "/Users/mbaechtold/.buildout/eggs/ZODB3-3.10.5-py2.7-macosx-10.11-x86_64.egg/ZODB/Connection.py", line 248, in get
    p, serial = self._storage.load(oid, '')
AttributeError: 'NoneType' object has no attribute 'load'
```