### PR TITLE
Add support for Plone 5

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ ftw.datepicker
 `ftw.datepicker` provides a date/time picker widget for your `z3c.form`
 fields using the jQuery based `DateTimePicker` widget from XDSoft
 (http://xdsoft.net/jqplugins/datetimepicker/). It is compatible with
-Plone 4.3 only.
+Plone 4.3 and 5.1.
 
 
 Screenshot

--- a/development.cfg
+++ b/development.cfg
@@ -1,4 +1,4 @@
 [buildout]
 extends =
-    test-plone-4.3.x.cfg
+    test-plone-5.1.x.cfg
     https://raw.github.com/4teamwork/ftw-buildouts/master/plone-development.cfg

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.2.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add Plone 5.1 support [njohner]
 
 
 1.2.1 (2017-06-22)

--- a/ftw/datepicker/configure.zcml
+++ b/ftw/datepicker/configure.zcml
@@ -4,6 +4,7 @@
     xmlns:browser="http://namespaces.zope.org/browser"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     xmlns:i18n="http://namespaces.zope.org/i18n"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="ftw.datepicker">
 
     <i18n:registerTranslations directory="locales" />
@@ -35,7 +36,12 @@
         layer="z3c.form.interfaces.IFormLayer"
         template="templates/datetimepicker_input.pt" />
 
-    <adapter
+    <adapter zcml:condition="installed plone-5"
+        factory=".widget.DateTimePickerWidgetFactory"
+        provides="z3c.form.interfaces.IFieldWidget"
+        for="plone.app.z3cform.interfaces.IDatetimeField" />
+
+    <adapter zcml:condition="installed plone-4"
         factory=".widget.DateTimePickerWidgetFactory"
         provides="z3c.form.interfaces.IFieldWidget"
         for="plone.app.z3cform.widget.IDatetimeField" />

--- a/ftw/datepicker/testing.py
+++ b/ftw/datepicker/testing.py
@@ -1,6 +1,7 @@
 from ftw.builder.testing import BUILDER_LAYER
 from ftw.builder.testing import functional_session_factory
 from ftw.builder.testing import set_builder_session_factory
+from pkg_resources import get_distribution
 from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import PLONE_FIXTURE
@@ -9,6 +10,8 @@ from zope.configuration import xmlconfig
 from Products.CMFCore.utils import getToolByName
 import transaction
 
+
+IS_PLONE_5 = get_distribution('Plone').version >= '5'
 
 class FtwDatepickerLayer(PloneSandboxLayer):
 
@@ -33,6 +36,8 @@ class FtwDatepickerLayer(PloneSandboxLayer):
         switch_language(portal, 'de')
         applyProfile(portal, 'plone.app.registry:default')
         applyProfile(portal, 'ftw.datepicker:default')
+        if IS_PLONE_5:
+            applyProfile(portal, 'plone.app.contenttypes:default')
 
 
 FTW_DATEPICKER_FIXTURE = FtwDatepickerLayer()
@@ -45,8 +50,14 @@ FTW_DATEPICKER_FUNCTIONAL_TESTING = FunctionalTesting(
 
 def switch_language(portal, lang):
     language_tool = getToolByName(portal, 'portal_languages')
-    language_tool.manage_setLanguageSettings(
-        lang, ['de', 'fr', 'en'],
-        setUseCombinedLanguageCodes=False, startNeutral=False)
+    if IS_PLONE_5:
+        language_tool.addSupportedLanguage("de")
+        language_tool.addSupportedLanguage("fr")
+        language_tool.settings.use_combined_language_codes = False
+        language_tool.setDefaultLanguage(lang)
+    else:
+        language_tool.manage_setLanguageSettings(
+            lang, ['de', 'fr', 'en'],
+            setUseCombinedLanguageCodes=False, startNeutral=False)
     portal.setLanguage(lang)
     transaction.commit()

--- a/ftw/datepicker/tests/test_widget.py
+++ b/ftw/datepicker/tests/test_widget.py
@@ -10,25 +10,6 @@ class TestWidget(FunctionalTestCase):
         super(TestWidget, self).setUp()
         self.grant('Manager')
 
-    def test_resources_are_installed(self):
-        js_registry = getToolByName(self.portal, 'portal_javascripts')
-
-        self.assertTrue(
-            '++resource++datetimepicker/js/datetimepicker-2.4.5/'
-            'jquery.datetimepicker.js'
-            in js_registry.getResourceIds())
-
-        self.assertTrue(
-            '++resource++datetimepicker/js/datetimepicker_widget.js'
-            in js_registry.getResourceIds())
-
-        css_registry = getToolByName(self.portal, 'portal_css')
-
-        self.assertTrue(
-            '++resource++datetimepicker/js/datetimepicker-2.4.5/'
-            'jquery.datetimepicker.css'
-            in css_registry.getResourceIds())
-
     @browsing
     def test_fill_datetime_field_with_browser(self, browser):
         browser.login().visit(view='test-z3cform-task')

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(name='ftw.datepicker',
       classifiers=[
         'Framework :: Plone',
         'Framework :: Plone :: 4.3',
+        'Framework :: Plone :: 5.1',
         'Intended Audience :: Developers',
         'Programming Language :: Python',
         ],

--- a/test-plone-5.1.x.cfg
+++ b/test-plone-5.1.x.cfg
@@ -1,0 +1,5 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-5.1.x.cfg
+
+package-name = ftw.datepicker


### PR DESCRIPTION
* The `IDatetimeField` interface has been moved from `widget` to `interfaces`
* `portal_languages` is now a utility `plone.i18n.utility.LanguageUtility` with a somewhat different interface.
* The registry test was testing an api so it was dropped.