### PR TITLE
Fix insert-after reference in the JS registry.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,7 @@ Changelog
 1.3.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Fix insert-after reference in the JS registry. [phgross]
 
 1.3.1 (2018-04-12)
 ------------------

--- a/ftw/datepicker/profiles/default/jsregistry.xml
+++ b/ftw/datepicker/profiles/default/jsregistry.xml
@@ -7,6 +7,6 @@
 
     <javascript id="++resource++datetimepicker/js/datetimepicker_widget.js"
                 compression="safe" enabled="True"
-                insert-after="++resource++datetimepicker/js/datetimepicker-2.5.18/jquery.datetimepicker.js" />
+                insert-after="++resource++datetimepicker/js/datetimepicker-2.5.18/jquery.datetimepicker.full.min.js" />
 
 </object>


### PR DESCRIPTION
With #17 we switched to the minified version of the datetimepicker plugin, but forgot to update the `insert-after` reference in the jsregistry.xml for the `datetimepicker_widget.js`.