### PR TITLE
JS: Fix issue with language format selection

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.3.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix issue with language format selection for deployments
+  with mutliple languages AND non-combined language codes.
+  [lgraf]
 
 
 1.3.2 (2018-04-13)

--- a/ftw/datepicker/resources/js/datetimepicker_widget.js
+++ b/ftw/datepicker/resources/js/datetimepicker_widget.js
@@ -11,7 +11,7 @@ $(function(){
             params['format'] = widget_data["format"][lang];
           }
           else {
-            params['format'] = widget_data[lang];
+            params['format'] = widget_data["formats"][lang];
           }
       }
       else if (widget_data['formats'][lang.split('-')[0]]){


### PR DESCRIPTION
This fixes an issue with language format selection for deployments with **mutliple languages** AND **non-combined language codes** (`de` instead of `de-ch`).

The `if`-branch in question only was taken when:
- There's more than one language
- The active language uses a non-combined language code (`de` instead of `de-ch`).

Fixes 4teamwork/opengever.core#4348