### PR TITLE
Disable autocomplete

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.3.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Disable autocompleting and autofilling of datepicker fields. [tarnap]
 
 
 1.3.3 (2018-05-24)

--- a/ftw/datepicker/templates/datetimepicker_input.pt
+++ b/ftw/datepicker/templates/datetimepicker_input.pt
@@ -1,4 +1,5 @@
 <input type="text"
+       autocomplete="off"
        tal:attributes="id view/id;
                        name view/name;
                        class view/klass;


### PR DESCRIPTION
This disables the autocompleting and autofilling of fields.

https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion

This seems not to work for Chrome users:
https://bugs.chromium.org/p/chromium/issues/detail?id=370363

The select2.js widget used in ftw.keywordwidget uses "off"
https://github.com/4teamwork/ftw.keywordwidget/blob/69bec20de3080d4c6ff786ea769c45f91145225b/ftw/keywordwidget/resources/select2/dist/js/select2.full.js#L1809
https://github.com/4teamwork/ftw.keywordwidget/blob/69bec20de3080d4c6ff786ea769c45f91145225b/ftw/keywordwidget/resources/select2/dist/js/select2.js#L1809

For consistency, "off" is selected.

The browser could be determined in the view and a value according to the browser could be returned, if the issue persists on the chrome browser.

<img width="1072" alt="screen shot 2018-07-11 at 08 30 46" src="https://user-images.githubusercontent.com/194114/42635001-19473d08-85e5-11e8-9d56-488242f4ab9f.png">

Resolves: https://github.com/4teamwork/opengever.core/issues/3772