### PR TITLE
Add javascipt recources conform to plone5

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.3.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Move ressources to plone bundle. [busykoala]
 
 
 1.3.4 (2018-07-23)

--- a/ftw/datepicker/configure.zcml
+++ b/ftw/datepicker/configure.zcml
@@ -29,6 +29,15 @@
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
 
+    <genericsetup:registerProfile
+        zcml:condition="have plone-5"
+        name="uninstall"
+        title="Uninstall ftw.datepicker"
+        directory="profiles/uninstall_plone5"
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
+        />
+
     <include package=".upgrades" />
 
     <class class=".widget.DateTimePickerWidget">

--- a/ftw/datepicker/configure.zcml
+++ b/ftw/datepicker/configure.zcml
@@ -12,9 +12,19 @@
     <browser:resourceDirectory name="datetimepicker" directory="resources" />
 
     <genericsetup:registerProfile
+        zcml:condition="not-have plone-5"
         name="default"
         title="ftw.datepicker"
         directory="profiles/default"
+        description="Register ftw.datepicker generally"
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
+    <genericsetup:registerProfile
+        zcml:condition="have plone-5"
+        name="default"
+        title="ftw.datepicker"
+        directory="profiles/default_plone5"
         description="Register ftw.datepicker generally"
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />

--- a/ftw/datepicker/profiles/default_plone5/browserlayer.xml
+++ b/ftw/datepicker/profiles/default_plone5/browserlayer.xml
@@ -1,0 +1,4 @@
+<layers>
+    <layer name="ftw.datepicker"
+           interface="ftw.datepicker.interfaces.IBrowserLayer"/>
+</layers>

--- a/ftw/datepicker/profiles/default_plone5/metadata.xml
+++ b/ftw/datepicker/profiles/default_plone5/metadata.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<metadata>
+    <dependencies>
+        <dependency>profile-collective.js.jqueryui:default</dependency>
+    </dependencies>
+</metadata>

--- a/ftw/datepicker/profiles/default_plone5/registry.xml
+++ b/ftw/datepicker/profiles/default_plone5/registry.xml
@@ -1,0 +1,47 @@
+<registry>
+
+    <record name="ftw.datepicker.interfaces.IDatetimeRegistry.formats">
+        <field type="plone.registry.field.Dict">
+            <title>The formats per language</title>
+            <key_type type="plone.registry.field.TextLine"/>
+            <value_type type="plone.registry.field.TextLine"/>
+        </field>
+        <value purge="false">
+            <element key="de">d.m.Y H:i</element>
+            <element key="fr">d/m/Y H:i</element>
+        </value>
+    </record>
+
+    <record name="ftw.datepicker.interfaces.IDatetimeRegistry.various">
+        <field type="plone.registry.field.Text">
+            <title>various</title>
+        </field>
+        <value>{"dayOfWeekStart": 1}</value>
+    </record>
+
+    <records prefix="plone.resources/datetimepicker_widget"
+             interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+        <value key="js">++resource++datetimepicker/js/datetimepicker_widget.js</value>
+        <value key="deps">jquery</value>
+    </records>
+
+    <records prefix="plone.resources/datetimepicker"
+             interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+        <value key="js">++resource++datetimepicker/js/datetimepicker-2.5.18/jquery.datetimepicker.full.min.js</value>
+        <value key="deps">jquery</value>
+    </records>
+
+    <records prefix="plone.bundles/ftw-datepicker-resources"
+             interface='Products.CMFPlone.interfaces.IBundleRegistry'>
+        <value key="resources">
+            <element>datetimepicker</element>
+            <element>datetimepicker_widget</element>
+        </value>
+        <value key="enabled">True</value>
+        <value key="depends">plone-legacy</value>
+        <value key="compile">False</value>
+        <value key="jscompilation">++plone++datetimepicker/ftw-datepicker-compiled.js</value>
+        <value key="merge_with">default</value>
+    </records>
+
+</registry>

--- a/ftw/datepicker/profiles/default_plone5/registry.xml
+++ b/ftw/datepicker/profiles/default_plone5/registry.xml
@@ -31,16 +31,25 @@
         <value key="deps">jquery</value>
     </records>
 
+    <records prefix="plone.resources/datetimepicker_css"
+             interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+        <value key="css">
+            <element>++resource++datetimepicker/js/datetimepicker-2.5.18/jquery.datetimepicker.css</element>
+        </value>
+    </records>
+
     <records prefix="plone.bundles/ftw-datepicker-resources"
              interface='Products.CMFPlone.interfaces.IBundleRegistry'>
         <value key="resources">
             <element>datetimepicker</element>
             <element>datetimepicker_widget</element>
+            <element>datetimepicker_css</element>
         </value>
         <value key="enabled">True</value>
         <value key="depends">plone-legacy</value>
         <value key="compile">False</value>
         <value key="jscompilation">++plone++datetimepicker/ftw-datepicker-compiled.js</value>
+        <value key="csscompilation">++plone++datetimepicker/ftw-datepicker-compiled.css</value>
         <value key="merge_with">default</value>
     </records>
 

--- a/ftw/datepicker/profiles/uninstall_plone5/registry.xml
+++ b/ftw/datepicker/profiles/uninstall_plone5/registry.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<registry>
+    <records prefix="plone.resources/datetimepicker_css"
+             interface='Products.CMFPlone.interfaces.IResourceRegistry'
+             remove="True"/>
+    <records prefix="plone.resources/datetimepicker_widget"
+             interface='Products.CMFPlone.interfaces.IResourceRegistry'
+             remove="True"/>
+    <records prefix="plone.resources/datetimepicker"
+             interface='Products.CMFPlone.interfaces.IResourceRegistry'
+             remove="True"/>
+    <records prefix="plone.bundles/ftw-datepicker-resources"
+             interface='Products.CMFPlone.interfaces.IBundleRegistry'
+             remove="True"/>
+</registry>


### PR DESCRIPTION
Configured like this the two ftw.datepicker resources will be listed on
the Site as separate resources but in production they are merged and
minified into the default file.

__Small Documentation of this Pull Request__

In production this merges the resources bundle `ftw-datepicker-resources` into default:
```
<value key="merge_with">default</value>
```

This is a point of failure if we try to create certain kind of subdirectories for the resources:
```
<value key="jscompilation">++plone++datetimepicker/ftw-datepicker-compiled.js</value>
```

Here we need to start with `plone.bundles/`:
```
<records prefix="plone.bundles/ftw-datepicker-resources"
```