### PR TITLE
Add plone5 condition for "Fix resource bundles" upgrade step.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.5.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- IResourceRegistry does not exist in plone4. Add condition to "Fix resource bundles" upgrade step. [2e12]
 
 
 1.5.0 (2019-12-16)

--- a/ftw/datepicker/upgrades/20191216171909_fix_resource_bundles/upgrade.py
+++ b/ftw/datepicker/upgrades/20191216171909_fix_resource_bundles/upgrade.py
@@ -1,9 +1,13 @@
 from ftw.upgrade import UpgradeStep
+import pkg_resources
 
+
+IS_PLONE_5 = pkg_resources.get_distribution('Products.CMFPlone').version >= '5'
 
 class FixResourceBundles(UpgradeStep):
     """Fix resource bundles.
     """
 
     def __call__(self):
-        self.install_upgrade_profile()
+        if IS_PLONE_5:
+            self.install_upgrade_profile()


### PR DESCRIPTION
Upgrade step "Fix resource bundles" fails on plone4 because "IResourceRegistry" isn't implemented in plone4.