### PR TITLE
Add timezone support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,64 @@ See http://xdsoft.net/jqplugins/datetimepicker/ for a full list of options.
 You could apply the widget even to a `TextLine` field if you need to.
 
 
+If you wish to use the Widget for a date field that needs a timezone, you can
+tell it so by setting ``default_timezone`` to an Olson DB/pytz timezone
+identifier or a callback (taking the context as an argument) returning such an
+identifier:
+
+.. code:: python
+
+    from plone.directives import form
+    from plone.supermodel import model
+    from ftw.datepicker.widget import DateTimePickerWidgetFactory
+
+    class MySchema(model.Schema):
+        form.widget('due_date',
+                    DateTimePickerWidgetFactory,
+                    default_timezone='Europe/Berlin') # or in
+        due_date = schema.Datetime()
+
+
+In case you want to use this widget for an already defined field you can do
+that too. In case of ``IEventBasic`` you must set the ``default_timezone`` due
+to how ``plone.appe.event`` works.
+
+.. code:: python
+
+    from plone.autoform.interfaces import WIDGETS_KEY
+
+    WIDGETS = {
+        MySchema: {'start_date': DatePickerFieldWidget,
+                   'end_date': DatePickerFieldWidget},
+    }
+
+    for schema, widget_config in WIDGETS.items():
+        values = schema.queryTaggedValue(WIDGETS_KEY, {})
+        values.update(widget_config)
+        schema.setTaggedValue(WIDGETS_KEY, values)
+
+    # Or with the default_timezone and/or config set:
+
+    from plone.app.event.base import default_timezone
+    from plone.app.event.dx.behaviors import IEventBasic
+    from plone.autoform.interfaces import WIDGETS_KEY
+    from plone.autoform.widgets import ParameterizedWidget
+
+    WIDGETS = {
+        IEventBasic: {'start': ParameterizedWidget(DatePickerFieldWidget,
+                                                   default_timezone=default_timezone,
+                                                   config=my_config),
+                      'end': ParameterizedWidget(DatePickerFieldWidget,
+                                                 default_timezone=default_timezone,
+                                                 config=my_config)},
+    }
+
+    for schema, widget_config in WIDGETS.items():
+        values = schema.queryTaggedValue(WIDGETS_KEY, {})
+        values.update(widget_config)
+        schema.setTaggedValue(WIDGETS_KEY, values)
+
+
 Development
 -----------
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.5.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add timezone support to the widget [Nachtalb]
 
 
 1.5.1 (2020-02-05)

--- a/ftw/datepicker/widget.py
+++ b/ftw/datepicker/widget.py
@@ -14,14 +14,21 @@ from ftw.datepicker.interfaces import IDatetimeRegistry
 
 
 class DateTimePickerWidget(widget.HTMLTextInputWidget, Widget):
-    """ Datepicker widget. """
+    """ Datepicker widget.
+
+    :param default_timezone: A Olson DB/pytz timezone identifier or a callback
+                             returning such an identifier.
+    :type default_timezone: String or callback
+    """
     implementsOnly(IDateTimePickerWidget)
 
     klass = u'datetimepicker-widget'
     config = None
+    default_timezone = None
 
-    def __init__(self, request, config=None):
+    def __init__(self, request, config=None, default_timezone=None):
         super(DateTimePickerWidget, self).__init__(request)
+        self.default_timezone = default_timezone
 
         self.loaded_config = config
         if callable(config):
@@ -56,8 +63,8 @@ DatePickerWidget = DateTimePickerWidget
 
 @adapter(IDateTimePickerWidget, IFormLayer)
 @implementer(IFieldWidget)
-def DateTimePickerWidgetFactory(field, request, config=None):
+def DateTimePickerWidgetFactory(field, request, config=None, default_timezone=None):
     """IFieldWidget factory for DateTimePickerWidget."""
-    return FieldWidget(field, DateTimePickerWidget(request, config))
+    return FieldWidget(field, DateTimePickerWidget(request, config, default_timezone))
 
 DatePickerFieldWidget = DateTimePickerWidgetFactory


### PR DESCRIPTION
- Add timezone support just like Plone's default DateTimePicker by setting the `default_timezone` to either a `pytz` timezone identifier or a callable that accepts a context and returns such an identifier. 
- Explain how it is used in the readme and point out that the timezone must be used when overriding `IEventBasic`'s `start` and `end` widget. 


`default_timezone` implementation copied from `plone.app.event==3.4.2` and `plone.app.z3cform==3.0.10`
