### PR TITLE
Remove no timezone support notice

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,15 +29,6 @@ Add ftw.datepicker to your buildout configuration:
 Import the generic setup profile for `ftw.datepicker`.
 
 
-WARNING
--------
-
-The datetime fields are not timezone aware!
-To implement it, please see how to do it at:
-
-https://github.com/plone/plone.app.event/blob/master/plone/app/event/dx/behaviors.py
-
-
 Usage
 -----
 


### PR DESCRIPTION
We now have optional timezone support so we don't need that warning in the readme any more.

> https://github.com/4teamwork/ftw.datepicker/pull/26#pullrequestreview-367317225

It is only a change in the readme so I don't think it needs a history entry.