### PR TITLE
Remove unnecessary registry field definition

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.6.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix fail on reinstallation on Plone 5 when upgrading from Plone 4 due to weird behaviour of its IDatetimeRegistry.formats field declaration in registry.xml [Nachtalb]
 
 
 1.6.0 (2020-02-27)

--- a/ftw/datepicker/profiles/default_plone5/registry.xml
+++ b/ftw/datepicker/profiles/default_plone5/registry.xml
@@ -1,21 +1,13 @@
 <registry>
 
-    <record name="ftw.datepicker.interfaces.IDatetimeRegistry.formats">
-        <field type="plone.registry.field.Dict">
-            <title>The formats per language</title>
-            <key_type type="plone.registry.field.TextLine"/>
-            <value_type type="plone.registry.field.TextLine"/>
-        </field>
+    <record interface="ftw.datepicker.interfaces.IDatetimeRegistry" field="formats">
         <value purge="false">
             <element key="de">d.m.Y H:i</element>
             <element key="fr">d/m/Y H:i</element>
         </value>
     </record>
 
-    <record name="ftw.datepicker.interfaces.IDatetimeRegistry.various">
-        <field type="plone.registry.field.Text">
-            <title>various</title>
-        </field>
+    <record interface="ftw.datepicker.interfaces.IDatetimeRegistry" field="various">
         <value>{"dayOfWeekStart": 1}</value>
     </record>
 


### PR DESCRIPTION
This field definition is only needed if no interface is given. By
default it uses the definition given by the interface.

This field definition also leads to some problems when upgrading from
Plone 4 to 5. I guess that the definition or internals of the schema
changed to some degree. Without the field definition in the registry.xml
it works fine for new installations and upgrades.