### PR TITLE
Register registry entries without field and interface declaration

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.6.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix reinstallation of the package if it was initially installed on 1.1.0 and 1.1.1 (see #30 for more details) [Nachtalb, maethu]
 
 
 1.6.1 (2020-07-29)

--- a/ftw/datepicker/profiles/default/registry.xml
+++ b/ftw/datepicker/profiles/default/registry.xml
@@ -11,10 +11,12 @@
         <element key="fr">d/m/Y H:i</element>
     </value>
 </record>
+
 <record name="ftw.datepicker.interfaces.IDatetimeRegistry.various">
     <field type="plone.registry.field.Text">
         <title>various</title>
     </field>
     <value>{"dayOfWeekStart": 1}</value>
 </record>
+
 </registry>

--- a/ftw/datepicker/profiles/default_plone5/registry.xml
+++ b/ftw/datepicker/profiles/default_plone5/registry.xml
@@ -1,15 +1,25 @@
 <registry>
 
-    <record interface="ftw.datepicker.interfaces.IDatetimeRegistry" field="formats">
+    <record name="ftw.datepicker.interfaces.IDatetimeRegistry.formats">
+        <field type="plone.registry.field.Dict">
+            <title>The formats per language</title>
+            <key_type type="plone.registry.field.TextLine" />
+            <value_type type="plone.registry.field.TextLine" />
+        </field>
         <value purge="false">
             <element key="de">d.m.Y H:i</element>
             <element key="fr">d/m/Y H:i</element>
         </value>
     </record>
 
-    <record interface="ftw.datepicker.interfaces.IDatetimeRegistry" field="various">
+    <record name="ftw.datepicker.interfaces.IDatetimeRegistry.various">
+        <field type="plone.registry.field.Text">
+            <title>various</title>
+        </field>
         <value>{"dayOfWeekStart": 1}</value>
     </record>
+
+
 
     <records prefix="plone.bundles/ftw-datepicker-resources"
              interface="Products.CMFPlone.interfaces.IBundleRegistry">

--- a/ftw/datepicker/upgrades/20200729153302_cleanup_datepickers_registry_entries/upgrade.py
+++ b/ftw/datepicker/upgrades/20200729153302_cleanup_datepickers_registry_entries/upgrade.py
@@ -1,0 +1,21 @@
+from ftw.upgrade import UpgradeStep
+from plone.registry.interfaces import IRegistry
+from zope.component import getUtility
+from plone.registry.interfaces import IInterfaceAwareRecord
+from zope.interface import noLongerProvides
+
+
+class CleanupDatepickersRegistryEntries(UpgradeStep):
+    """Cleanup datepickers registry entries.
+    """
+
+    record_names = [
+        'ftw.datepicker.interfaces.IDatetimeRegistry.formats',
+        'ftw.datepicker.interfaces.IDatetimeRegistry.various',
+    ]
+
+    def __call__(self):
+        registry = getUtility(IRegistry)
+        for record in [registry.records.get(name) for name in self.record_names]:
+            noLongerProvides(record, IInterfaceAwareRecord)
+            record.field.interfaceName = None


### PR DESCRIPTION
__Problem__

In the release 1.1.0 and 1.1.1 ftw.datepicker added registry entries as
follows:
```xml
<record interface="ftw.datepicker.interfaces.IDatetimeRegistry" field="formats">
    <value purge="false">
        <element key="de">d.m.Y H:i</element>
        <element key="fr">d/m/Y H:i</element>
    </value>
</record>
```

Like this, the created record in the registry has a field which about the
interface (due to the `interface="..."`). If a field knows about the
`interface` the record will provide IInterfaceAwareRecord __on
initialization__.

In version 1.2.0 the record declaration was changed to:
```xml
<record name="ftw.datepicker.interfaces.IDatetimeRegistry.formats">
    <field type="plone.registry.field.Dict">
        <title>The formats per language</title>
        <key_type type="plone.registry.field.TextLine" />
        <value_type type="plone.registry.field.TextLine" />
    </field>
    <value purge="false">
        <element key="de">d.m.Y H:i</element>
        <element key="fr">d/m/Y H:i</element>
    </value>
</record>
```

In here we do not define the interface anymore but do define the field
itself.

Now when you have initially installed version 1.1.0 or 1.1.1 the field
knows the interface. When you reinstall the profile with version 1.2.0
and above plone.app.registry will get the existing record from the
registry. At that moment it sees that its field knows about the
interface and thus provides the IInterfaceAwareRecord interface. During
the registration of the entry, it finds that we declare the `field`
manually in the XML. Because of that, it creates a new field in case
something has changed. During this creation process of the field, it lets
the field know about the interface. __BUT__ because we didn't define an
interface this time in the record (`interface="..."`) it sets `None` instead of our
actual interface.

Now during the rest of the installation process, the record provides
IInterfaceAwareRecord even though the field does __not__ know about the
interface anymore.

Later on, in the record registration process, this will trigger the
`redispatchInterfaceAwareRecordEvents` subscriber from `plone.registry`.
At that moment he thinks the record knows about the interface because it
still provides IInterfaceAwareRecord. This causes a failure when trying
to resolve that interface.

---

__Solution__

Our solution is to remove the interface from the field before we
reinstall the package. So that during the installation it never sets the
IInterfaceAwareRecord interface.